### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xLFE
-[![Build Status](https://travis-ci.org/exercism/xlfe.svg?branch=master)](https://travis-ci.org/exercism/xlfe)
-[![Build status](https://ci.appveyor.com/api/projects/status/2i4og4ghwwlynx29/branch/master?svg=true)](https://ci.appveyor.com/project/yurrriq/xlfe/branch/master)
+[![Build Status](https://travis-ci.org/exercism/lfe.svg?branch=master)](https://travis-ci.org/exercism/lfe)
+[![Build status](https://ci.appveyor.com/api/projects/status/2i4og4ghwwlynx29/branch/master?svg=true)](https://ci.appveyor.com/project/yurrriq/lfe/branch/master)
 
 Exercism problems in Lisp Flavoured Erlang.
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "lfe",
   "language": "Lisp Flavoured Erlang (LFE)",
-  "repository": "https://github.com/exercism/xlfe",
+  "repository": "https://github.com/exercism/lfe",
   "active": true,
   "deprecated": [
     "accumulate"


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1