### PR TITLE
Rename the language to LFE

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,6 @@
 {
+  "language": "LFE",
+  "blurb": "Lisp Flavoured Erlang is one of those eat your cake and have it too programming languages. As they say: It's the best of Erlang and of Lisp; at the same time!",
   "active": true,
   "exercises": [
     {
@@ -247,6 +249,5 @@
       "uuid": "d706e999-482a-42de-8492-0a65e6258c19"
     }
   ],
-  "foregone": [],
-  "language": "Lisp Flavoured Erlang (LFE)"
+  "foregone": []
 }


### PR DESCRIPTION
Lisp Flavoured Erlang is colloquially referred to as LFE. I would like to
suggest that we use this as the name, and use the 'blurb' (which will show
up right underneath the name in the v2 site) in order to give people the
full meaning.

Visually this will be easier to deal with in the new site (we're currently
jumping through a few small hoops in places to replace the full name with LFE).