### PR TITLE
difference-of-squares: renamed square-of-sums to square-of-sum

### DIFF
--- a/exercises/difference-of-squares/src/example.lfe
+++ b/exercises/difference-of-squares/src/example.lfe
@@ -1,10 +1,10 @@
 (defmodule difference-of-squares
-  (export (square-of-sums 1)
+  (export (square-of-sum 1)
           (sum-of-squares 1)))
 
 (defun square (x) (trunc (math:pow x 2)))
 
-(defun square-of-sums (x) (square (lists:sum (lists:seq 1 x))))
+(defun square-of-sum (x) (square (lists:sum (lists:seq 1 x))))
 
 ;; Traverses the list only once.
 (defun sum-of-squares (x)

--- a/exercises/difference-of-squares/test/difference-of-squares-tests.lfe
+++ b/exercises/difference-of-squares/test/difference-of-squares-tests.lfe
@@ -6,5 +6,5 @@
 
 (deftest ten
   (let ((summed  (difference-of-squares:sum-of-squares 10))
-        (squared (difference-of-squares:square-of-sums 10)))
+        (squared (difference-of-squares:square-of-sum 10)))
     (is-equal 2640 (- squared summed))))


### PR DESCRIPTION
In exercise "difference-of-squares", renamed `square-of-sums` to `square-of-sum`.