### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Lisp Flavoured Erlang (AKA LFE) is a lisp syntax front-end to the Erlang compiler. 
 Code produced with it is compatible with "normal" Erlang code. 
 LFE is a (proper) Lisp based on the features and limitations of the Erlang VM.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 First, make sure you have Erlang installed, following the instructions on the
 [Erlang][1] installation page as appropriate.
 [1]: /languages/erlang

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -4,7 +4,7 @@ First, make sure you have Erlang installed, following the instructions on the
 [Erlang][1] installation page as appropriate.
 [1]: /languages/erlang
 
-### Homebrew for Mac OS X
+## Homebrew for Mac OS X
 
 Update your Homebrew to latest:
 
@@ -18,7 +18,7 @@ Install LFE:
 $ brew install lfe
 ```
 
-### Using a docker container
+## Using a docker container
 If you just want to quickly take a look at LFE without polluting your
 system with new packages, you can just pull a docker container with
 LFE preinstalled.
@@ -52,7 +52,7 @@ ok
 Nice! Use `(exit)` or Ctrl-C (C-c) twice to exit.
 
 
-### Installing from Source
+## Installing from Source
 Install your system's "developer tools" or "essential build packages", `git`
 and Erlang's `erl`.
 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Exercism provides exercises and feedback but can be difficult to jump into for
 those learning LFE for the first time. These resources can help you get started:
 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,0 +1,2 @@
+# Resources
+

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 For each example, the following general steps are required.
 
 First, change directory to the exercise you want to practice, in

--- a/exercises/practice/bob/.meta/description.md
+++ b/exercises/practice/bob/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Bob is a lackadaisical teenager. In conversation, his responses are very limited.
 
 Bob answers 'Sure.' if you ask him a question.


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
