### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,25 @@
+{
+  "docs": [
+    {
+      "uuid": "7046fa9d-bea4-4395-9e8f-5ce2a3003bf8",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing LFE locally",
+      "blurb": "Learn how to install LFE locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "75f3bd52-0258-4b12-9cba-443b0de5d9e4",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn LFE",
+      "blurb": "An overview of how to get started from scratch with LFE"
+    },
+    {
+      "uuid": "66360c69-4433-4a8f-a73a-d5423f34450f",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the LFE track",
+      "blurb": "Learn how to test your LFE exercises on Exercism"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
