### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/src/hello-world.lfe
+++ b/exercises/practice/hello-world/src/hello-world.lfe
@@ -2,4 +2,4 @@
   (export (hello-world 0)))
 
 (defun hello-world ()
-  "Hello, world!")
+  "Goodbye, Mars!")


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46