### PR TITLE
Fix "World" case in hello-world

### DIFF
--- a/exercises/practice/hello-world/.meta/example.lfe
+++ b/exercises/practice/hello-world/.meta/example.lfe
@@ -2,4 +2,4 @@
   (export (hello-world 0)))
 
 (defun hello-world ()
-  "Hello, world!")
+  "Hello, World!")

--- a/exercises/practice/hello-world/test/hello-world-tests.lfe
+++ b/exercises/practice/hello-world/test/hello-world-tests.lfe
@@ -5,4 +5,4 @@
 (include-lib "ltest/include/ltest-macros.lfe")
 
 (deftest hello-world
-  (is-equal "Hello, world!" (hello-world:hello-world)))
+  (is-equal "Hello, World!" (hello-world:hello-world)))


### PR DESCRIPTION
@ErikSchierboom One tiny detail about LFE's hello-world. The instructions (global for all tracks) say `"Hello, World!" but the test spelled it `world` instead of `World`.