### PR TITLE
Sync docs and metadata

### DIFF
--- a/exercises/practice/allergies/.docs/instructions.md
+++ b/exercises/practice/allergies/.docs/instructions.md
@@ -22,6 +22,6 @@ Now, given just that score of 34, your program should be able to say:
 - Whether Tom is allergic to any one of those allergens listed above.
 - All the allergens Tom is allergic to.
 
-Note: a given score may include allergens **not** listed above (i.e.  allergens that score 256, 512, 1024, etc.).
+Note: a given score may include allergens **not** listed above (i.e. allergens that score 256, 512, 1024, etc.).
 Your program should ignore those components of the score.
 For example, if the allergy score is 257, your program should only report the eggs (1) allergy.

--- a/exercises/practice/binary/.docs/instructions.md
+++ b/exercises/practice/binary/.docs/instructions.md
@@ -20,7 +20,7 @@ A number 23 in base 10 notation can be understood as a linear combination of pow
 - The rightmost digit gets multiplied by 10^0 = 1
 - The next number gets multiplied by 10^1 = 10
 - ...
-- The *n*th number gets multiplied by 10^*(n-1)*.
+- The nth number gets multiplied by 10^_(n-1)_.
 - All these values are summed.
 
 So: `23 => 2*10^1 + 3*10^0 => 2*10 + 3*1 = 23 base 10`

--- a/exercises/practice/circular-buffer/.docs/instructions.md
+++ b/exercises/practice/circular-buffer/.docs/instructions.md
@@ -4,39 +4,55 @@ A circular buffer, cyclic buffer or ring buffer is a data structure that uses a 
 
 A circular buffer first starts empty and of some predefined length.
 For example, this is a 7-element buffer:
-<!-- prettier-ignore -->
-    [ ][ ][ ][ ][ ][ ][ ]
+
+```text
+[ ][ ][ ][ ][ ][ ][ ]
+```
 
 Assume that a 1 is written into the middle of the buffer (exact starting location does not matter in a circular buffer):
-<!-- prettier-ignore -->
-    [ ][ ][ ][1][ ][ ][ ]
+
+```text
+[ ][ ][ ][1][ ][ ][ ]
+```
 
 Then assume that two more elements are added — 2 & 3 — which get appended after the 1:
-<!-- prettier-ignore -->
-    [ ][ ][ ][1][2][3][ ]
+
+```text
+[ ][ ][ ][1][2][3][ ]
+```
 
 If two elements are then removed from the buffer, the oldest values inside the buffer are removed.
 The two elements removed, in this case, are 1 & 2, leaving the buffer with just a 3:
-<!-- prettier-ignore -->
-    [ ][ ][ ][ ][ ][3][ ]
+
+```text
+[ ][ ][ ][ ][ ][3][ ]
+```
 
 If the buffer has 7 elements then it is completely full:
-<!-- prettier-ignore -->
-    [5][6][7][8][9][3][4]
+
+```text
+[5][6][7][8][9][3][4]
+```
 
 When the buffer is full an error will be raised, alerting the client that further writes are blocked until a slot becomes free.
 
 When the buffer is full, the client can opt to overwrite the oldest data with a forced write.
 In this case, two more elements — A & B — are added and they overwrite the 3 & 4:
-<!-- prettier-ignore -->
-    [5][6][7][8][9][A][B]
+
+```text
+[5][6][7][8][9][A][B]
+```
 
 3 & 4 have been replaced by A & B making 5 now the oldest data in the buffer.
 Finally, if two elements are removed then what would be returned is 5 & 6 yielding the buffer:
-<!-- prettier-ignore -->
-    [ ][ ][7][8][9][A][B]
+
+```text
+[ ][ ][7][8][9][A][B]
+```
 
 Because there is space available, if the client again uses overwrite to store C & D then the space where 5 & 6 were stored previously will be used not the location of 7 & 8.
 7 is still the oldest element and the buffer is once again full.
-<!-- prettier-ignore -->
-    [C][D][7][8][9][A][B]
+
+```text
+[C][D][7][8][9][A][B]
+```

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -21,6 +21,5 @@
     ]
   },
   "blurb": "Implement a clock that handles times without dates.",
-  "source": "Pairing session with Erin Drummond",
-  "source_url": "https://twitter.com/ebdrummond"
+  "source": "Pairing session with Erin Drummond"
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -21,7 +21,7 @@
       "rebar.config"
     ]
   },
-  "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
-  "source": "Exercise by the JumpstartLab team for students at The Turing School of Software and Design.",
+  "blurb": "Change the data format for scoring a game to more easily add other languages.",
+  "source": "Based on an exercise by the JumpstartLab team for students at The Turing School of Software and Design.",
   "source_url": "https://turing.edu"
 }

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -20,5 +20,5 @@
   },
   "blurb": "Calculate the date of meetups.",
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
-  "source_url": "https://twitter.com/copiousfreetime"
+  "source_url": "http://www.copiousfreetime.org/"
 }

--- a/exercises/practice/phone-number/.docs/instructions.md
+++ b/exercises/practice/phone-number/.docs/instructions.md
@@ -5,18 +5,20 @@ Clean up user-entered phone numbers so that they can be sent SMS messages.
 The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda.
 All NANP-countries share the same international country code: `1`.
 
-NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number.
-The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
+NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as _area code_, followed by a seven-digit local number.
+The first three digits of the local number represent the _exchange code_, followed by the unique four-digit number which is the _subscriber number_.
 
 The format is usually represented as
 
 ```text
-(NXX)-NXX-XXXX
+NXX NXX-XXXX
 ```
 
 where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9.
 
-Your task is to clean up differently formatted telephone numbers by removing punctuation and the country code (1) if present.
+Sometimes they also have the country code (represented as `1` or `+1`) prefixed.
+
+Your task is to clean up differently formatted telephone numbers by removing punctuation and the country code if present.
 
 For example, the inputs
 

--- a/exercises/practice/series/.docs/instructions.md
+++ b/exercises/practice/series/.docs/instructions.md
@@ -15,5 +15,5 @@ And the following 4-digit series:
 
 And if you ask for a 6-digit series from a 5-digit string, you deserve whatever you get.
 
-Note that these series are only required to occupy *adjacent positions* in the input;
-the digits need not be *numerically consecutive*.
+Note that these series are only required to occupy _adjacent positions_ in the input;
+the digits need not be _numerically consecutive_.

--- a/exercises/practice/space-age/.docs/instructions.md
+++ b/exercises/practice/space-age/.docs/instructions.md
@@ -16,4 +16,10 @@ be able to say that they're 31.69 Earth-years old.
 
 If you're wondering why Pluto didn't make the cut, go watch [this YouTube video][pluto-video].
 
+Note: The actual length of one complete orbit of the Earth around the sun is closer to 365.256 days (1 sidereal year).
+The Gregorian calendar has, on average, 365.2425 days.
+While not entirely accurate, 365.25 is the value used in this exercise.
+See [Year on Wikipedia][year] for more ways to measure a year.
+
 [pluto-video]: https://www.youtube.com/watch?v=Z_2gbGXzFbs
+[year]: https://en.wikipedia.org/wiki/Year#Summary

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -25,5 +25,5 @@
   },
   "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
   "source": "Conversation with James Edward Gray II",
-  "source_url": "https://twitter.com/jeg2"
+  "source_url": "http://graysoftinc.com/"
 }


### PR DESCRIPTION
```
./bin/configlet sync  --docs --filepaths --metadata -uy           
Updating cached 'problem-specifications' data...
Checking exercises...
[warn] docs: instructions unsynced: allergies
[warn] docs: instructions unsynced: binary
[warn] docs: instructions unsynced: circular-buffer
[warn] docs: instructions unsynced: phone-number
[warn] docs: instructions unsynced: series
[warn] docs: instructions unsynced: space-age
Updated the docs for 6 Practice Exercises
[warn] metadata: unsynced: clock
[warn] metadata: unsynced: etl
[warn] metadata: unsynced: meetup
[warn] metadata: unsynced: strain
Updated the metadata for 4 Practice Exercises
```