### PR TITLE
Update difference of square tests

### DIFF
--- a/exercises/practice/difference-of-squares/.meta/example.lfe
+++ b/exercises/practice/difference-of-squares/.meta/example.lfe
@@ -1,6 +1,7 @@
 (defmodule difference-of-squares
   (export (square-of-sum 1)
-          (sum-of-squares 1)))
+          (sum-of-squares 1)
+          (difference-of-squares 1)))
 
 (defun square (x) (trunc (math:pow x 2)))
 
@@ -13,6 +14,8 @@
       (+ (square x) sum))
     0
     (lists:seq 1 x)))
+
+(defun difference-of-squares (x) (- (square-of-sum x) (sum-of-squares x)))
 
 ;; Unnecessarily traverses the list twice, though maybe easier to read.
 ;; (defun sum-of-squares (x)

--- a/exercises/practice/difference-of-squares/src/difference-of-squares.lfe
+++ b/exercises/practice/difference-of-squares/src/difference-of-squares.lfe
@@ -1,0 +1,10 @@
+(defmodule difference-of-squares
+  (export (square-of-sum 1)
+          (sum-of-squares 1)
+          (difference-of-squares 1)))
+
+; Please implement the square-of-sum function.
+
+; Please implement the sum-of-squares function.
+
+; Please implement the difference-of-squares function.

--- a/exercises/practice/difference-of-squares/test/difference-of-squares-tests.lfe
+++ b/exercises/practice/difference-of-squares/test/difference-of-squares-tests.lfe
@@ -4,7 +4,29 @@
 
 (include-lib "ltest/include/ltest-macros.lfe")
 
-(deftest ten
-  (let ((summed  (difference-of-squares:sum-of-squares 10))
-        (squared (difference-of-squares:square-of-sum 10)))
-    (is-equal 2640 (- squared summed))))
+(deftest square-of-sum-1
+  (is-equal (difference-of-squares:square-of-sum 1) 1))
+
+(deftest square-of-sum-5
+  (is-equal (difference-of-squares:square-of-sum 5) 225))
+
+(deftest square-of-sum-100
+  (is-equal (difference-of-squares:square-of-sum 100) 25502500))
+
+(deftest sum-of-squares-1
+  (is-equal (difference-of-squares:sum-of-squares 1) 1))
+
+(deftest sum-of-squares-5
+  (is-equal (difference-of-squares:sum-of-squares 5) 55))
+
+(deftest sum-of-squares-100
+  (is-equal (difference-of-squares:sum-of-squares 100) 338350))
+
+(deftest difference-of-squares-1
+  (is-equal (difference-of-squares:difference-of-squares 1) 0))
+
+(deftest difference-of-squares-5
+  (is-equal (difference-of-squares:difference-of-squares 5) 170))
+
+(deftest difference-of-squares-100
+  (is-equal (difference-of-squares:difference-of-squares 100) 25164150))


### PR DESCRIPTION
@ErikSchierboom, I was looking at this exercise for an example and saw it wasn't synced with problem-specifications. I took the liberty to expand the stub as well. This breaks seven solutions by adding `difference-of-squares`, but it brings the the test suite more in line with the instructions. 