### PR TITLE
Add missing tests for atbash-cipher

### DIFF
--- a/exercises/practice/atbash-cipher/src/atbash-cipher.lfe
+++ b/exercises/practice/atbash-cipher/src/atbash-cipher.lfe
@@ -1,0 +1,5 @@
+(defmodule atbash-cipher
+  (export (encode 1)
+          (decode 1)))
+
+  ; Please implement the encode and decode functions.

--- a/exercises/practice/atbash-cipher/test/atbash-cipher-tests.lfe
+++ b/exercises/practice/atbash-cipher/test/atbash-cipher-tests.lfe
@@ -45,3 +45,11 @@
 (deftest decode-all-the-letters
   (is-equal "thequickbrownfoxjumpsoverthelazydog"
             (atbash-cipher:decode "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt")))
+
+(deftest decode-with-too-many-spaces
+  (is-equal "exercism"
+            (atbash-cipher:decode "vc vix    r hn")))
+
+(deftest decode-with-no-spaces
+  (is-equal "anobstacleisoftenasteppingstone"
+            (atbash-cipher:decode "zmlyhgzxovrhlugvmzhgvkkrmthglmv")))


### PR DESCRIPTION
These two tests were in the toml file but not in the suite.