### PR TITLE
Add missing exercise authors

### DIFF
--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,8 +1,9 @@
 {
-  "authors": [],
-  "contributors": [
-    "tmcgilchrist",
+  "authors": [
     "yurrriq"
+  ],
+  "contributors": [
+    "tmcgilchrist"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,8 +1,9 @@
 {
-  "authors": [],
-  "contributors": [
-    "tmcgilchrist",
+  "authors": [
     "yurrriq"
+  ],
+  "contributors": [
+    "tmcgilchrist"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -1,8 +1,9 @@
 {
-  "authors": [],
-  "contributors": [
-    "tmcgilchrist",
+  "authors": [
     "yurrriq"
+  ],
+  "contributors": [
+    "tmcgilchrist"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,9 +1,10 @@
 {
-  "authors": [],
+  "authors": [
+    "yurrriq"
+  ],
   "contributors": [
     "Scientifica96",
-    "tmcgilchrist",
-    "yurrriq"
+    "tmcgilchrist"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,9 +1,10 @@
 {
-  "authors": [],
+  "authors": [
+    "yurrriq"
+  ],
   "contributors": [
     "petertseng",
-    "tmcgilchrist",
-    "yurrriq"
+    "tmcgilchrist"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,8 +1,9 @@
 {
-  "authors": [],
-  "contributors": [
-    "etrepum",
+  "authors": [
     "yurrriq"
+  ],
+  "contributors": [
+    "etrepum"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/parallel-letter-frequency/.meta/config.json
+++ b/exercises/practice/parallel-letter-frequency/.meta/config.json
@@ -1,8 +1,9 @@
 {
-  "authors": [],
-  "contributors": [
-    "tmcgilchrist",
+  "authors": [
     "yurrriq"
+  ],
+  "contributors": [
+    "tmcgilchrist"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,9 +1,10 @@
 {
-  "authors": [],
+  "authors": [
+    "yurrriq"
+  ],
   "contributors": [
     "NobbZ",
-    "tmcgilchrist",
-    "yurrriq"
+    "tmcgilchrist"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,8 +1,9 @@
 {
-  "authors": [],
-  "contributors": [
-    "tmcgilchrist",
+  "authors": [
     "yurrriq"
+  ],
+  "contributors": [
+    "tmcgilchrist"
   ],
   "files": {
     "solution": [


### PR DESCRIPTION
I found a few more exercise configs missing authors. I assigned authorship using git blame for the corresponding example.lfe files.