### PR TITLE
Fix `binary` breakage in CI

### DIFF
--- a/bin/verify-exercises
+++ b/bin/verify-exercises
@@ -8,7 +8,13 @@ run_test() {
     mkdir -p ${temp_dir}
     
     cp -r "$1/." $temp_dir
-    cp $temp_dir/.meta/example.lfe $temp_dir/src/$slug.lfe
+
+    outpath=$temp_dir/src/$slug.lfe
+    if [ "$slug" = "binary" ]; then
+        outpath=$temp_dir/src/binary-string.lfe
+    fi
+
+    cp $temp_dir/.meta/example.lfe $outpath
 
     (cd /opt/test-runner && bin/run.sh $slug $temp_dir $temp_dir) || exit 1
 

--- a/exercises/practice/binary/.meta/example.lfe
+++ b/exercises/practice/binary/.meta/example.lfe
@@ -2,9 +2,5 @@
   (export (to-decimal 1)))
 
 (defun to-decimal (string)
-  (try (element 2 (lists:foldr #'to-decimal/2 #(0 0) string))
-    (catch (_ 0))))
+  (list_to_integer string 2))
 
-(defun to-decimal
-  ([#\0 `#(,n ,acc)] `#(,(+ n 1) ,acc))
-  ([#\1 `#(,n ,acc)] `#(,(+ n 1) ,(+ acc (trunc (math:pow 2 n))))))

--- a/exercises/practice/binary/.meta/tests.toml
+++ b/exercises/practice/binary/.meta/tests.toml
@@ -38,18 +38,25 @@ description = "binary ignores leading zeros"
 
 [44f7d8b1-ddc3-4751-8be3-700a538b421c]
 description = "2 is not a valid binary digit"
+include = false
 
 [c263a24d-6870-420f-b783-628feefd7b6e]
 description = "a number containing a non-binary digit is invalid"
+include = false
 
 [8d81305b-0502-4a07-bfba-051c5526d7f2]
 description = "a number with trailing non-binary characters is invalid"
+include = false
 
 [a7f79b6b-039a-4d42-99b4-fcee56679f03]
 description = "a number with leading non-binary characters is invalid"
+include = false
 
 [9e0ece9d-b8aa-46a0-a22b-3bed2e3f741e]
 description = "a number with internal non-binary characters is invalid"
+include = false
 
 [46c8dd65-0c32-4273-bb0d-f2b111bccfbd]
 description = "a number and a word whitespace separated is invalid"
+include = false
+

--- a/exercises/practice/binary/src/binary-string.app.src
+++ b/exercises/practice/binary/src/binary-string.app.src
@@ -1,9 +1,9 @@
 %% -*- erlang -*-
-{application, 'binary',
+{application, 'binary-string',
  [{description, ""},
   {vsn, "0.0.1"},
   {modules,
-   ['binary']},
+   ['binary-string']},
   {registered, []},
   {applications,
    [kernel, stdlib]},

--- a/exercises/practice/binary/src/binary-string.lfe
+++ b/exercises/practice/binary/src/binary-string.lfe
@@ -1,0 +1,5 @@
+(defmodule binary-string
+  (export (to-decimal 1)))
+
+; please implement the to-decimal function
+

--- a/exercises/practice/binary/test/binary-string-tests.lfe
+++ b/exercises/practice/binary/test/binary-string-tests.lfe
@@ -29,5 +29,5 @@
   (is-equal 1128 (binary-string:to-decimal "10001101000")))
 
 (deftest binary-ignores-leading-zeros
-  (is-equal 31 (binary-string:from-decimal "000011111")))
+  (is-equal 31 (binary-string:to-decimal "000011111")))
 

--- a/exercises/practice/binary/test/binary-string-tests.lfe
+++ b/exercises/practice/binary/test/binary-string-tests.lfe
@@ -28,3 +28,6 @@
 (deftest binary-10001101000-is-decimal-1128
   (is-equal 1128 (binary-string:to-decimal "10001101000")))
 
+(deftest binary-ignores-leading-zeros
+  (is-equal 31 (binary-string:from-decimal "000011111")))
+

--- a/exercises/practice/binary/test/binary-string-tests.lfe
+++ b/exercises/practice/binary/test/binary-string-tests.lfe
@@ -4,21 +4,27 @@
 
 (include-lib "ltest/include/ltest-macros.lfe")
 
-(deftest one (check "1"))
+(deftest binary-0-is-decimal-0
+  (is-equal 0 (binary-string:to-decimal "0")))
 
-(deftest two (check "10"))
+(deftest binary-1-is-decimal-1
+  (is-equal 1 (binary-string:to-decimal "1")))
 
-(deftest three (check "11"))
+(deftest binary-10-is-decimal-2
+  (is-equal 2 (binary-string:to-decimal "10")))
 
-(deftest four (check "100"))
+(deftest binary-11-is-decimal-3
+  (is-equal 3 (binary-string:to-decimal "11")))
 
-(deftest nine (check "1001"))
+(deftest binary-100-is-decimal-4
+  (is-equal 4 (binary-string:to-decimal "100")))
 
-(deftest twenty-six (check "11010"))
+(deftest binary-1001-is-decimal-9
+  (is-equal 9 (binary-string:to-decimal "1001")))
 
-(deftest large (check "10001101000"))
+(deftest binary-11010-is-decimal-26
+  (is-equal 26 (binary-string:to-decimal "11010")))
 
-(deftest carrot (is-equal 0 (binary-string:to-decimal "carrot")))
+(deftest binary-10001101000-is-decimal-1128
+  (is-equal 1128 (binary-string:to-decimal "10001101000")))
 
-(defun check (string)
-  (is-equal (list_to_integer string 2) (binary-string:to-decimal string)))


### PR DESCRIPTION
CI breaks on binary so I'm working on updating the exercise. It's deprecated so I'm not planning on adding the missing tests at the moment unless I need to rework the example.