### PR TITLE
Bump rebar3_lfe version for resistor-color-duo

### DIFF
--- a/exercises/practice/resistor-color-duo/rebar.config
+++ b/exercises/practice/resistor-color-duo/rebar.config
@@ -1,4 +1,4 @@
-{plugins, [{rebar3_lfe, "0.4.3"}]}.
+{plugins, [{rebar3_lfe, "0.4.10"}]}.
 
 {provider_hooks, [{post, [{compile, {lfe, compile}}]}]}.
 


### PR DESCRIPTION
Other exercises use 0.4.10. This exercise passes the CI as-is but times out in the editor so I'm seeing if this solves the issue.