### PR TITLE
Update `series` tests and example

### DIFF
--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -3,6 +3,7 @@
     "yurrriq"
   ],
   "contributors": [
+    "BNAndras",
     "tmcgilchrist"
   ],
   "files": {

--- a/exercises/practice/series/.meta/example.lfe
+++ b/exercises/practice/series/.meta/example.lfe
@@ -1,11 +1,16 @@
 (defmodule series
   (export (from-string 2)))
 
-(defun from-string (width string) (rows (length string) width string))
-
-(defun rows
-  ([length width (= (cons _head tail) string)] (when (> length width))
-   (let ((`#(,row ,_rest) (lists:split width string)))
-     (cons row (rows (- length 1) width tail))))
-  ([_length _width string]
-   `(,string)))
+(defun from-string
+  ([_ ""]
+    (error "empty series"))
+  ([slice _] (when (=< slice 0))
+    (error "slice length must be positive"))
+  ([slice series] (when (> slice (length series)))
+    (error "slice length is too large"))
+  ([slice series] 
+   (let* ((final-start (- (length series) slice))
+          (all-starts (lists:seq 0 final-start)))
+     (lists:map
+       (lambda (i) (lists:sublist series (+ i 1) slice))
+       all-starts))))

--- a/exercises/practice/series/.meta/tests.toml
+++ b/exercises/practice/series/.meta/tests.toml
@@ -30,6 +30,9 @@ description = "slices of a long series"
 [6d235d85-46cf-4fae-9955-14b6efef27cd]
 description = "slice length is too large"
 
+[d7957455-346d-4e47-8e4b-87ed1564c6d7]
+description = "slice length is way too large"
+
 [d34004ad-8765-4c09-8ba1-ada8ce776806]
 description = "slice length cannot be zero"
 

--- a/exercises/practice/series/test/series-tests.lfe
+++ b/exercises/practice/series/test/series-tests.lfe
@@ -4,8 +4,41 @@
 
 (include-lib "ltest/include/ltest-macros.lfe")
 
-(deftest three
-  (is-equal (series:from-string 3 "01234") '("012" "123" "234")))
+(deftest slices-of-one-from-one
+  (is-equal (series:from-string 1 "1")
+            '("1")))
 
-(deftest four
-  (is-equal (series:from-string 4 "01234") '("0123" "1234")))
+(deftest slices-of-one-from-two
+  (is-equal (series:from-string 1 "12")
+            '("1" "2")))
+
+(deftest slices-of-two
+  (is-equal (series:from-string 2 "35")
+            '("35")))
+
+(deftest slices-of-two-overlap
+  (is-equal (series:from-string 2 "9142")
+            '("91" "14" "42")))
+
+(deftest slices-can-include-duplicates
+  (is-equal (series:from-string 3 "777777")
+            '("777" "777" "777" "777")))
+
+(deftest slices-of-a-long-series
+  (is-equal (series:from-string 5 "918493904243")
+            '("91849" "18493" "84939" "49390" "93904" "39042" "90424" "04243")))
+
+(deftest slice-length-is-too-large
+    (is-error _ (series:from-string 6 "12345")))
+
+(deftest slice-length-is-way-too-large
+    (is-error _ (series:from-string 42 "12345")))
+
+(deftest slice-length-cannot-be-zero
+    (is-error _ (series:from-string 0 "12345")))
+
+(deftest slice-length-cannot-be-negative
+    (is-error _ (series:from-string -1 "123")))
+
+(deftest empty-series-is-invalid
+    (is-error _ (series:from-string 1 "")))


### PR DESCRIPTION
No canonical tests were being used hence the almost complete overhaul. There is only one completion for this exercise to date so we won't break a whole lot here.

I implemented all the tests, but we can discuss that. Do we want the error validation tests? Should they be errors or should we return false values here.

I kept the expected argument order the same from before even though the problem specs has the series first and then the slice. Should we swap?

Does `series:from-string` make sense as a name? The tested property is `slices` so we can change it.