### PR TITLE
Sync `reverse-string` tests

### DIFF
--- a/exercises/practice/reverse-string/.meta/example.lfe
+++ b/exercises/practice/reverse-string/.meta/example.lfe
@@ -2,4 +2,8 @@
   (export (string 1)))
 
 (defun string (str)
-    (lists:reverse str))
+  (let ((reversed (string:reverse (iolist_to_binary str))))
+    (binary_to_list
+      (if (is_binary reversed)
+          reversed
+          (unicode:characters_to_binary reversed)))))

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -26,3 +26,15 @@ description = "a palindrome"
 
 [b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
 description = "an even-sized word"
+
+[1bed0f8a-13b0-4bd3-9d59-3d0593326fa2]
+description = "wide characters"
+comment = "included as optional test"
+
+[93d7e1b8-f60f-4f3c-9559-4056e10d2ead]
+description = "grapheme cluster with pre-combined form"
+comment = "included as optional test"
+
+[1028b2c1-6763-4459-8540-2da47ca512d9]
+description = "grapheme clusters"
+comment = "included as optional test"

--- a/exercises/practice/reverse-string/test/reverse-string-tests.lfe
+++ b/exercises/practice/reverse-string/test/reverse-string-tests.lfe
@@ -23,3 +23,18 @@
 (deftest reverses-an-even-sized-word
   (is-equal "reward"
             (reverse:string "drawer")))
+
+;; Uncomment the following Unicode tests locally if you want an extra challenge.
+;; The online test runner won't run these.
+;;
+;; (deftest wide-characters
+;;   (is-equal "猫子"
+;;             (reverse:string "子猫")))
+;;
+;; (deftest reverses-grapheme-cluster-with-pre-combined-form
+;;   (is-equal "dnatsnehctsrüW"
+;;             (reverse:string "Würstchenstand")))
+;; 
+;; (deftest reverses-grapheme-clusters
+;;   (is-equal "มรกแรปโนยขีเผู้"
+;;             (reverse:string "ผู้เขียนโปรแกรม")))


### PR DESCRIPTION
Related to #293. The three Unicode tests raise the difficulty and would likely break most if not all existing solutions. I decided instead to add them as an optional challenge for students working locally. 